### PR TITLE
Update Banner Tanks with new visual cues and a fix

### DIFF
--- a/scripts/vscripts/tankextensions/bannertank.nut
+++ b/scripts/vscripts/tankextensions/bannertank.nut
@@ -133,7 +133,6 @@ TankExt.NewTankType("bannertank*", {
 		bNoSelfEffect = sTankName.find("_noselfeffect") ? true : false
 		iActiveBanners <- 0
 		hSprites <- []
-		iCurrentOffset <- 0
 
 		function AddSprite(iBuffType)
 		{


### PR DESCRIPTION
The banner tanks had really hard to notice visual cues, this branch adds the appropriate effect sprites on top similar to the vaccinator tanks. It also fixes a bug where the _noselfeffect parameter does not work on the on take damage game event hook.
![20250422232827_1](https://github.com/user-attachments/assets/05a893c8-1626-4b7b-9f49-dc92450d6e6e)
